### PR TITLE
Fix for #2. Force reinstall of api npm dependencies.

### DIFF
--- a/playbooks/redeploy/provision/roles/api/files/build-api.sh
+++ b/playbooks/redeploy/provision/roles/api/files/build-api.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 . /usr/lib/ckan/default/bin/activate
 cd /opt/cadasta/cadasta-api
-npm install
+npm -f install
 pip install -r requirements.txt
 grunt updateDocs


### PR DESCRIPTION
Added '-f' flag to npm install command in build-api.sh to force reinstall of npm dependencies during redeployment. Another (possibly better) solution might be to delete the cadasta-api/node_modules directory before running npm install?
