### PR TITLE
Fixing permissions on ona media directory.

### DIFF
--- a/playbooks/deploy/provision/roles/ona/tasks/main.yml
+++ b/playbooks/deploy/provision/roles/ona/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Create ONA media directory
   become: yes
   become_user: root
-  file: path=/var/ona/media state=directory owner=www-data group=www-data
+  file: path=/var/ona/media state=directory owner=ona group=www-data mode=0765
 
 - name: Create Postgres password file for ONA
   become: yes


### PR DESCRIPTION
Setting owner of /var/ona/media to ona and group to www-data with permissions to 0765 as both ona and www-data processes need rw access to this directory. Owner and group should possibly be reversed but leaving for now as its working as is.
